### PR TITLE
Fix order auto export

### DIFF
--- a/admin/class-parcelpro-admin.php
+++ b/admin/class-parcelpro-admin.php
@@ -231,8 +231,14 @@ class Parcelpro_Admin
             $method = $this->settings['availability'];
             $countries = ($method == 'specific') ? $this->settings['countries'] : null;
             $country = wc_get_order($order_id)->get_shipping_country();
+            $order_status = wc_get_order($order_id)->get_status();
 
-            if ($allowed_export == 'yes' && ($method == 'all' || in_array($country, $countries)) && ($this->settings['auto_export_on_state'] == wc_get_order($order_id)->post_status)) {
+            // Ensure the order status always starts with 'wc-', same as the options from `wc_get_order_statuses`.
+            if (strpos($order_status, 'wc-') !== 0) {
+                $order_status = 'wc-' . $order_status;
+            }
+
+            if ($allowed_export == 'yes' && ($method == 'all' || in_array($country, $countries)) && ($this->settings['auto_export_on_state'] == $order_status)) {
                 $this->export_order($order_id);
             }
         }

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,11 @@
 Changelog
 =========
 
-ParcelPro Shipment module voor Wordpress / WooCommerce
+ParcelPro Shipment module voor WordPress / WooCommerce
 (c) Parcel Pro [parcelpro.nl]
+
+## 1.6.2 - 2023-10-20 =
+* Fix automatisch aanmelden
 
 ## 1.6.1 - 2023-09-05 =
 * Fix pakketpunten Homerr

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "parcelpro/woocommerce",
   "description": "Verzendmodule om gemakkelijk orders in te laden in het verzendsysteem van Parcel Pro.",
   "type": "wordpress-plugin",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "require": {
     "php": ">=7.1"
   },

--- a/includes/class-parcelpro.php
+++ b/includes/class-parcelpro.php
@@ -67,7 +67,7 @@ class Parcelpro
     public function __construct()
     {
         $this->plugin_name = 'parcelpro';
-        $this->version = '1.6.1';
+        $this->version = '1.6.2';
 
         $this->load_dependencies();
         $this->define_shipping_method();

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Tags: Shipping, Verzending, Pakketten, PostNL, DHL, DPD, UPS, Multi Carrier, Sho
 Requires at least: 3.0.1
 Tested up to: 6.1.1
 Requires PHP: 5.2.4
-Stable tag: 1.6.1
+Stable tag: 1.6.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ Deze wordt door de plugin aangeroepen als apply_filter('parcelpro_format_order_d
 Zie de handleiding voor meer details.
 
 == Changelog ==
+= 1.6.2 - 2023-10-20 =
+* Fix automatisch aanmelden
+
 = 1.6.1 - 2023-09-05 =
 * Fix pakketpunten Homerr
 

--- a/woocommerce-parcelpro.php
+++ b/woocommerce-parcelpro.php
@@ -16,7 +16,7 @@
  * Plugin Name:     WooCommerce Parcel Pro
  * Plugin URI:      https://www.parcelpro.nl/koppelingen/woocommerce/
  * Description:     Geef klanten de mogelijkheid om hun pakket af te halen bij een afhaalpunt in de buurt. Daarnaast exporteert de plug-in uw zendingen direct in het verzendsysteem van Parcel Pro.
- * Version:         1.6.1
+ * Version:         1.6.2
  * Author:          Parcel Pro
  * Author URI:      https://www.parcelpro.nl/
  * License:         GPL-3.0+


### PR DESCRIPTION
In the `auto_export` function, getting the order status was done incorrectly. This raised a PHP notice and caused the auto export to not work. The notice:

```
[19-Oct-2023 14:29:44 UTC] PHP Notice:  Function post_status was called <strong>incorrectly</strong>. Order properties should not be accessed directly. Backtrace: do_action('load-woocommerce_page_wc-orders'), WP_Hook->do_action, WP_Hook->apply_filters, Automattic\WooCommerce\Internal\Admin\Orders\PageController->__call, call_user_func_array, Automattic\WooCommerce\Internal\Admin\Orders\PageController->handle_load_page_action, Automattic\WooCommerce\Internal\Admin\Orders\PageController->setup_action_edit_order, Automattic\WooCommerce\Internal\Admin\Orders\PageController->prepare_order_edit_form, Automattic\WooCommerce\Internal\Admin\Orders\Edit->setup, Automattic\WooCommerce\Internal\Admin\Orders\Edit->handle_order_update, do_action('woocommerce_process_shop_order_meta'), WP_Hook->do_action, WP_Hook->apply_filters, WC_Meta_Box_Order_Data::save, WC_Order->save, WC_Order->status_transition, do_action('woocommerce_order_status_changed'), WP_Hook->do_action, WP_Hook->apply_filters, Parcelpro_Admin->auto_export, WC_Abstract_Legacy_Order->__get, wc_doing_it_wrong Please see <a href="https://wordpress.org/documentation/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.0.) in /var/www/html/wp-includes/functions.php on line 5905
```

Tested this code with WooCommerce 8.1.1 and 8.2.1.