### PR TITLE
Fix order actions box in WooCommerce 8

### DIFF
--- a/admin/class-parcelpro-admin.php
+++ b/admin/class-parcelpro-admin.php
@@ -143,18 +143,24 @@ class Parcelpro_Admin
      * Creates content for the order actions page
      *
      * @since    1.0.0
+     * @param $order WC_Order | null
      */
-    public function create_box_content()
+    public function create_box_content($order)
     {
         global $post_id;
 
-        $label_link = wp_nonce_url(admin_url('edit.php?&action=parcelpro-label&order_id=' . $post_id), 'parcelpro-label');
-        $track_link = wp_nonce_url(admin_url('edit.php?&action=parcelpro-track&order_id=' . $post_id), 'parcelpro-track');
-        $ship_link = wp_nonce_url(admin_url('edit.php?&action=parcelpro-export&order_id=' . $post_id), 'parcelpro-export');
-        $package_link = wp_nonce_url(admin_url('edit.php?&action=parcelpro-package&order_id=' . $post_id), 'parcelpro-package');
+        $order_id = $post_id;
+        if (!$order_id && $order) {
+            $order_id = $order->get_id();
+        }
 
-        if ($post_id) {
-            $data_order = $this->format_order_data($post_id);
+        $label_link = wp_nonce_url(admin_url('edit.php?&action=parcelpro-label&order_id=' . $order_id), 'parcelpro-label');
+        $track_link = wp_nonce_url(admin_url('edit.php?&action=parcelpro-track&order_id=' . $order_id), 'parcelpro-track');
+        $ship_link = wp_nonce_url(admin_url('edit.php?&action=parcelpro-export&order_id=' . $order_id), 'parcelpro-export');
+        $package_link = wp_nonce_url(admin_url('edit.php?&action=parcelpro-package&order_id=' . $order_id), 'parcelpro-package');
+
+        if ($order_id) {
+            $data_order = $this->format_order_data($order_id);
             if (is_array($data_order)) {
                 if (array_key_exists('shipping_method', $data_order)) {
                     $options = get_option('woocommerce_parcelpro_shipping_settings');
@@ -198,12 +204,12 @@ class Parcelpro_Admin
                 }
             }
 
-            if ($status = get_post_meta($post_id, '_parcelpro_status', true)) {
-                if ($shipmentId = get_post_meta($post_id, '_parcelpro_id', true)) {
+            if ($status = get_post_meta($order_id, '_parcelpro_status', true)) {
+                if ($shipmentId = get_post_meta($order_id, '_parcelpro_id', true)) {
                     $shipment = json_decode($this->api->shipments($shipmentId), true);
 
                     if (isset($shipment[0]['TrackingUrl'])) {
-                        update_post_meta($post_id, '_parcelpro_track_url', $shipment[0]['TrackingUrl']);
+                        update_post_meta($order_id, '_parcelpro_track_url', $shipment[0]['TrackingUrl']);
                     }
 
                     include(plugin_dir_path(__FILE__) . 'partials/parcelpro-admin-order-actions-after.php');

--- a/admin/class-parcelpro-admin.php
+++ b/admin/class-parcelpro-admin.php
@@ -133,10 +133,9 @@ class Parcelpro_Admin
         add_meta_box(
             'parcelpro',
             'Parcel Pro',
-            array($this, 'create_box_content'),
-            'shop_order',
-            'side',
-            'default'
+            [$this, 'create_box_content'],
+            ['shop_order', 'woocommerce_page_wc-orders'],
+            'side'
         );
     }
 

--- a/admin/class-parcelpro-admin.php
+++ b/admin/class-parcelpro-admin.php
@@ -143,15 +143,21 @@ class Parcelpro_Admin
      * Creates content for the order actions page
      *
      * @since    1.0.0
-     * @param $order WC_Order | null
+     * @param $order WC_Order | WP_Post | null
      */
     public function create_box_content($order)
     {
         global $post_id;
 
         $order_id = $post_id;
-        if (!$order_id && $order) {
+        if ($order instanceof WC_Order) {
             $order_id = $order->get_id();
+
+            // In WooCommerce 8, orders are automatically saved as a draft.
+            // So we need to check if this is an automatic draft or not.
+            if ($order->get_status() === 'auto-draft') {
+                $order_id = null;
+            }
         }
 
         $label_link = wp_nonce_url(admin_url('edit.php?&action=parcelpro-label&order_id=' . $order_id), 'parcelpro-label');

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ Changelog
 ParcelPro Shipment module voor WordPress / WooCommerce
 (c) Parcel Pro [parcelpro.nl]
 
+## 1.6.9 - 2023-11-02 =
+* Fix actions on edit order screen in WooCommerce 8
+
 ## 1.6.8 - 2023-10-31 =
 * Remove fragile requirements checks
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "parcelpro/woocommerce",
   "description": "Verzendmodule om gemakkelijk orders in te laden in het verzendsysteem van Parcel Pro.",
   "type": "wordpress-plugin",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "require": {
     "php": ">=7.1"
   },

--- a/includes/class-parcelpro.php
+++ b/includes/class-parcelpro.php
@@ -154,7 +154,9 @@ class Parcelpro
         $this->loader->add_action('woocommerce_order_status_changed', $plugin_admin, 'auto_export');
         $this->loader->add_action('admin_footer', $plugin_admin, 'add_bulk_actions');
         $this->loader->add_action('load-edit.php', $plugin_admin, 'action_handler');
+
         $this->loader->add_action('add_meta_boxes_shop_order', $plugin_admin, 'add_order_actions');
+        $this->loader->add_action('add_meta_boxes', $plugin_admin, 'add_order_actions');
 
         $this->loader->add_filter('handle_bulk_actions-woocommerce_page_wc-orders', $plugin_admin, 'action_handler');
     }

--- a/includes/class-parcelpro.php
+++ b/includes/class-parcelpro.php
@@ -67,7 +67,7 @@ class Parcelpro
     public function __construct()
     {
         $this->plugin_name = 'parcelpro';
-        $this->version = '1.6.8';
+        $this->version = '1.6.9';
 
         $this->load_dependencies();
         $this->define_shipping_method();

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Tags: Shipping, Verzending, Pakketten, PostNL, DHL, DPD, UPS, Multi Carrier, Sho
 Requires at least: 3.0.1
 Tested up to: 6.3.2
 Requires PHP: 5.2.4
-Stable tag: 1.6.8
+Stable tag: 1.6.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ Deze wordt door de plugin aangeroepen als apply_filter('parcelpro_format_order_d
 Zie de handleiding voor meer details.
 
 == Changelog ==
+= 1.6.9 - 2023-11-02 =
+* Fix actions on edit order screen in WooCommerce 8
+
 = 1.6.8 - 2023-10-31 =
 * Remove fragile requirements checks
 

--- a/woocommerce-parcelpro.php
+++ b/woocommerce-parcelpro.php
@@ -16,7 +16,7 @@
  * Plugin Name:     WooCommerce Parcel Pro
  * Plugin URI:      https://www.parcelpro.nl/koppelingen/woocommerce/
  * Description:     Geef klanten de mogelijkheid om hun pakket af te halen bij een afhaalpunt in de buurt. Daarnaast exporteert de plug-in uw zendingen direct in het verzendsysteem van Parcel Pro.
- * Version:         1.6.8
+ * Version:         1.6.9
  * Author:          Parcel Pro
  * Author URI:      https://www.parcelpro.nl/
  * License:         GPL-3.0+


### PR DESCRIPTION
Fixes this meta box on the edit order screen for WooCommerce 8:

![image](https://github.com/parcel-pro-nl/woocommerce-plugin/assets/5592716/d186d491-c039-449d-8433-4562b4677d26)
