### PR TITLE
Fix to avoid unnecessary type calls

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.14 - 2023-11-22
+* Fix to avoid unnecessary type calls
+
 ## 1.6.13 - 2023-11-22
 * Fix nonce validation for non-parcelpro actions in filter
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "parcelpro/woocommerce",
   "description": "Verzendmodule om gemakkelijk orders in te laden in het verzendsysteem van Parcel Pro.",
   "type": "wordpress-plugin",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "require": {
     "php": ">=7.1"
   },

--- a/includes/class-parcelpro-api.php
+++ b/includes/class-parcelpro-api.php
@@ -79,6 +79,7 @@ class ParcelPro_API
             if (!get_option('woocommerce_parcelpro_shipping_types')) {
                 update_option('woocommerce_parcelpro_shipping_types', $response);
             }
+            update_option('woocommerce_parcelpro_shipping_types_updated', current_time('mysql'));
         } else {
             $response = get_option('woocommerce_parcelpro_shipping_types');
         }


### PR DESCRIPTION
Tijdstip werd nooit geüpdatet waardoor we altijd een type call uitvoeren