### PR TITLE
Clean up getDeliveryDate function

### DIFF
--- a/admin/class-parcelpro-shipping.php
+++ b/admin/class-parcelpro-shipping.php
@@ -236,7 +236,7 @@ class ParcelPro_Shipping extends WC_Shipping_Method
                         $package['destination']['postcode']
                     );
 
-                    if ($delivery_expected instanceof DateTimeInterface) {
+                    if ($delivery_expected) {
                         $formattedDeliveryDate = ' (' . $this->formatDeliveryDate($delivery_expected) . ')';
                     }
                 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 1.7.3 - 2024-03-19
+* Improve error handling in the getDeliveryDate function
+
 ## 1.7.2 - 2024-03-04
 * Fixed a bug that would incorrectly display a wrong expected datetime
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "parcelpro/woocommerce",
   "description": "Verzendmodule om gemakkelijk orders in te laden in het verzendsysteem van Parcel Pro.",
   "type": "wordpress-plugin",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "require": {
     "php": ">=7.1",
     "ext-curl": "*",

--- a/includes/class-parcelpro-api.php
+++ b/includes/class-parcelpro-api.php
@@ -311,12 +311,12 @@ class ParcelPro_API
      * @param DateTimeInterface $dateTime The date on which the package will be handed over to the carrier.
      * @param $postcode string The postal code of the package destination.
      *
-     * @return DateTimeImmutable|false|string
+     * @return DateTimeImmutable|false
      */
     public function getDeliveryDate(string $carrier, \DateTimeInterface $dateTime, string $postcode)
     {
         if (!$postcode) {
-            return $postcode;
+            return false;
         }
         $postcode = str_replace(' ', '', $postcode);
 
@@ -359,7 +359,7 @@ class ParcelPro_API
                     $responseBody
                 ));
             }
-            return "200";
+            return false;
         }
 
         $responseJson = json_decode($responseBody, true);
@@ -380,7 +380,7 @@ class ParcelPro_API
                     $responseBody
                 ));
             }
-            return $carrier;
+            return false;
         }
 
         return \DateTimeImmutable::createFromFormat('Y-m-d', $rawDate);

--- a/tests/helpers/navigate.ts
+++ b/tests/helpers/navigate.ts
@@ -4,7 +4,7 @@ import { expect, Page } from '@playwright/test';
  * Navigate to a WooCommerce page by clicking a link in the menu.
  */
 export async function navigateWooCommerce(page: Page, name: string) {
-  await page.getByRole('link', { name: 'WooCommerce' }).click();
+  await page.getByRole('link', { name: 'WooCommerce', exact: true }).click();
   await expect(page).toHaveTitle(/WooCommerce/);
   await page
     .locator('#toplevel_page_woocommerce')


### PR DESCRIPTION
The `getDeliveryDate` function now returns `false` instead of a string when any failure happens.